### PR TITLE
Change the connection timeout to 30s

### DIFF
--- a/app/src/main/java/com/gianlu/aria2app/api/NetUtils.java
+++ b/app/src/main/java/com/gianlu/aria2app/api/NetUtils.java
@@ -29,7 +29,7 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 
 public final class NetUtils {
-    public static final int HTTP_TIMEOUT = 5; // sec
+    public static final int HTTP_TIMEOUT = 30; // sec
 
     public static boolean isUrlValid(String address, int port, String endpoint, boolean encryption) {
         try {


### PR DESCRIPTION
In my env, the old value (5s) always cause SSL shakehand timeout. My network is mobile network, and the aria2 is in a router. So I'd like to extend it to (30s) for stability.